### PR TITLE
Use log timestamps for measurement

### DIFF
--- a/Getipinfo.py
+++ b/Getipinfo.py
@@ -58,7 +58,37 @@ iforg    = os.getenv('INFLUX_ORG')
 iftoken  = os.getenv('INFLUX_TOKEN')
 
 # take a timestamp for this measurement
-time = datetime.datetime.utcnow()
+oldtime = str(sys.argv[6]) #30/May/2023:14:16:48 +0000 to 2009-11-10T23:00:00.123456Z
+#transform month
+month = oldtime[3:6]
+if month == 'Jan':
+    month = '01'
+elif month =='Feb':
+    month = '02'
+elif month =='Mar':
+    month = '03'
+elif month =='Apr':
+    month = '04'
+elif month =='May':
+    month = '05'
+elif month =='Jun':
+    month = '06'
+elif month =='Jul':
+    month = '07'
+elif month =='Aug':
+    month = '08'
+elif month =='Sep':
+    month = '09'
+elif month =='Oct':
+    month = '10'
+elif month =='Nov':
+    month = '11'
+else:
+    month = '12'
+
+# build new time
+time=oldtime[7:11]+'-'+month+'-'+oldtime[0:2]+'T'+oldtime[12:20]+'.000000Z'
+print('Measurement Time: ', time)
 
 ifclient = influxdb_client.InfluxDBClient(
     url=ifhost,
@@ -91,6 +121,8 @@ point.field("Target", Target)
 point.field("Name", Country)
 point.field("duration", duration)
 point.field("metric", 1)
+
+point.time(time)
 
 write_api.write(bucket=ifbucket, org=iforg, record=point)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # npmGrafStats
-NginxProxyManager Grafana Statistic.
+NginxProxyManager Grafana Statistics.
 
 This project analyzes the logs of the Nginx Proxy Manager and exports it to InfluxDB to be used in a Grafana Dashboard.
 
@@ -7,6 +7,7 @@ It saves following Data from the Revers-Proxy and Redirection Logs:
 - source IP
 - target IP in your home network set in NPM
 - the targeted domain
+- the measurement time
 - the Data of the source IP from GeoLite2-City.mmdb
   - Country
   - Coordinates

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@
 - use logtime and not hosttime to save the stats
 - Stop gathering after few days
 
+## v2.2.0
+Removes duplicate logs of the same Connection in case of a restart of NpmGrafStats
+- add time to influx measurement
+- convert [30/May/2023:14:16:48 +0000] to 2009-11-10T23:00:00.123456Z RFC 3339
+  - Timezone is not converted! Stays UTC
+
 ## v2.1.1
 - fix redirection logs
 - added Redirections and ReverseProxy Dashboard to Grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
 
   influxdb:
     image: influxdb:2.7-alpine
+    restart: unless-stopped
     environment:
       DOCKER_INFLUXDB_INIT_MODE: 'setup'
       DOCKER_INFLUXDB_INIT_USERNAME: '<replace>'
@@ -69,6 +70,7 @@ services:
 
   geoipupdate:
     image: maxmindinc/geoipupdate
+    restart: unless-stopped
     environment:
       GEOIPUPDATE_ACCOUNT_ID: '<replace>'
       GEOIPUPDATE_LICENSE_KEY: '<replace>'
@@ -90,6 +92,7 @@ services:
 
   grafana:
     image: grafana/grafana-oss
+    restart: unless-stopped
     ports:
       - '3000:3000'
     volumes:

--- a/sendips.sh
+++ b/sendips.sh
@@ -28,10 +28,14 @@ do
     # save from 14 postion after space and only the first digits found to length 
     length=`echo $line | awk -F ' ' '{print$14}' | grep -m 1 -o '[[:digit:]]*'`
 
+    # get time from logs
+    measurementtime=`echo ${line:1:26} `
+    #echo "measurement time: $measurementtime"
+
     #Idea of getting device
     #device=`echo $line | grep -e ""'('*')'""`
 
-    python /root/.config/NPMGRAF/Getipinfo.py "$outsideip" "$targetdomain" "$length" "$targetip" "ReverseProxyConnections"
+    python /root/.config/NPMGRAF/Getipinfo.py "$outsideip" "$targetdomain" "$length" "$targetip" "ReverseProxyConnections" "$measurementtime"
 
   fi
 done

--- a/sendredirectionips.sh
+++ b/sendredirectionips.sh
@@ -21,16 +21,20 @@ do
   then
     echo "Internal IP: $outsideip called for redirection: $targetdomain"
   else  
-    echo "external IP called redirection"    
+    #echo "external IP called redirection"    
 
     # What does length say? 
     # save from 14 postion after space and only the first digits found to length 
     #length=`echo $line | awk -F ' ' '{print$14}' | grep -m 1 -o '[[:digit:]]*'`
 
+    # get time from logs
+    measurementtime=`echo ${line:1:26} `
+    #echo "measurement time: $measurementtime"
+
     #Idea of getting device
     #device=`echo $line | grep -e ""'('*')'""`
 
-    python /root/.config/NPMGRAF/Getipinfo.py "$outsideip" "$targetdomain" "0" "redirect" "Redirections"
+    python /root/.config/NPMGRAF/Getipinfo.py "$outsideip" "$targetdomain" "0" "redirect" "Redirections" "$measurementtime"
 
   fi
 done


### PR DESCRIPTION
Use log timestamps for measurement to get precise logs and prevent duplicate logs in case of a container restart.
