### PR TITLE
Enable recognizing internal ipv6; process access, and *_proxy logs; cache abuseipdb data for 24 hours; persistent storage for cache

### DIFF
--- a/Getipinfo.py
+++ b/Getipinfo.py
@@ -10,11 +10,15 @@ print('**************** start *********************')
 measurement_name = sys.argv[4]  # get measurement from argv
 print('Measurement-name: ' + measurement_name)
 
-# --- Cache Configuration ---
-NPMGRAF_HOME = "/root/.config/NPMGRAF"
-CACHE_FILE = os.path.join(NPMGRAF_HOME, "abuseip_cache.json")
+# --- Configuration for Persistent Data ---
+DATA_DIR = "/data"
+CACHE_FILE = os.path.join(DATA_DIR, "abuseip_cache.json")
 CACHE_EXPIRATION_HOURS = 24
-# --- End Cache Configuration ---
+# --- End Configuration ---
+
+# Ensure the data directory exists
+if not os.path.exists(DATA_DIR):
+    os.makedirs(DATA_DIR)
 
 # Function to load the cache from the file
 def load_cache():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,12 @@ services:
       INFLUX_BUCKET: 'npmgrafstats'
       INFLUX_ORG: 'npmgrafstats'
       INFLUX_TOKEN: '<replace>' # REQUIRED! insert after first run and manual token creation
+      ABUSEIP_KEY: '<YOUR_ABUSEIPDB_API_KEY_HERE>' # Add your AbuseIPDB key here
     volumes:
       - /opt/npmplus/nginx:/nginx
       - ./geolite:/geolite
-      - ./monitoringips.txt:/monitoringips.txt # optional only mount if preexists and a wanted feature
+      # THE CHANGE: Mount a single directory for all persistent data
+      - ./npmgraf_data:/data
     depends_on:
       - geoipupdate
       - npmplus
@@ -58,13 +60,13 @@ services:
   portainer:
     image: portainer/portainer-ce:latest
     restart: always
-    ports: 
+    ports:
       - '8000:8000'
       - '9000:9000'
       - '9443:9443'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./portainer_data:/data 
+      - ./portainer_data:/data
 
   grafana:
     image: grafana/grafana-oss
@@ -72,4 +74,4 @@ services:
     ports:
       - '3000:3000'
     volumes:
-      - ./grafana-storage:/var/lib/grafana # after start: sudo chown 472:472 grafana-storage 
+      - ./grafana-storage:/var/lib/grafana # after start: sudo chown 472:472 grafana-storage


### PR DESCRIPTION
- Enable recognition of internal ipv6 patterns
- Scan access.log, and all logs like *_proxy.log
- Cache abuse ip data for 24 hours to prevent repeated query for the same IP. This should help prevent exhaust the daily free quota of 1000. I hit 222 in a few minutes without this. Home Assistant sends a lot of pings!
- Modify config to enable persistent storage config for cache and monitoring ip files